### PR TITLE
Surface partial sub-agent output on iteration exhaustion

### DIFF
--- a/src/Elwood/Claude.hs
+++ b/src/Elwood/Claude.hs
@@ -10,6 +10,7 @@ module Elwood.Claude
     -- * Agent Loop
     AgentConfig (..),
     AgentResult (..),
+    ExhaustionInfo (..),
     AgentObserver (..),
     RateLimitCallback,
     TextCallback,

--- a/src/Elwood/Claude/AgentLoop.hs
+++ b/src/Elwood/Claude/AgentLoop.hs
@@ -2,12 +2,14 @@ module Elwood.Claude.AgentLoop
   ( runAgentTurn,
     AgentConfig (..),
     AgentResult (..),
+    ExhaustionInfo (..),
+    formatExhaustion,
   )
 where
 
 import Control.Concurrent.Async (mapConcurrently)
 import Control.Exception (SomeAsyncException, SomeException, fromException, throwIO, try)
-import Data.Aeson (Value (..), encode)
+import Data.Aeson (Value (..), encode, object, (.=))
 import Data.ByteString.Lazy qualified as LBS
 import Data.Set (Set)
 import Data.Text (Text)
@@ -43,16 +45,28 @@ import Elwood.Tools.Registry
     lookupTool,
     toolSchemas,
   )
-import Elwood.Tools.Types (ApprovalFunction, ApprovalOutcome (..), Tool (..), ToolResult (..))
+import Elwood.Tools.Types (ApprovalFunction, ApprovalOutcome (..), FailureMode (..), Tool (..), ToolResult (..), failureTag)
 
 -- | Result of running an agent turn
 data AgentResult
   = -- | Success with response text and all messages (for persistence)
     AgentSuccess Text [ClaudeMessage]
+  | -- | Iteration cap hit before end_turn. Carries best-effort partial output
+    -- so the caller can salvage it rather than discard the turn.
+    AgentExhausted ExhaustionInfo
   | -- | Error that should be shown to user
     AgentError Text
   | -- | Cancelled by user via /stop. The turn is discarded.
     AgentCancelled
+  deriving stock (Show)
+
+-- | Partial result returned when the agent loop hits 'maxIterations'.
+data ExhaustionInfo = ExhaustionInfo
+  { partialOutput :: Text,
+    iterationsUsed :: Int,
+    toolsCalled :: Int,
+    messages :: [ClaudeMessage]
+  }
   deriving stock (Show)
 
 -- | Configuration for the agent loop (all environment/config params)
@@ -110,6 +124,14 @@ runAgentTurn cfg history userMessage = do
   result <- agentLoop cfg msgs 0
   pure $ case result of
     AgentSuccess text allMsgs -> AgentSuccess text (drop histLen allMsgs)
+    AgentExhausted info ->
+      AgentExhausted
+        ExhaustionInfo
+          { partialOutput = info.partialOutput,
+            iterationsUsed = info.iterationsUsed,
+            toolsCalled = info.toolsCalled,
+            messages = drop histLen info.messages
+          }
     AgentCancelled -> AgentCancelled
     err -> err
 
@@ -121,8 +143,21 @@ agentLoop ::
   IO AgentResult
 agentLoop cfg msgs iteration
   | iteration >= cfg.agentProfile.maxIterations.getPositive = do
-      logError cfg.logger "Agent loop exceeded max iterations" []
-      pure $ AgentError $ formatNotify Error "**Agent loop:** `exceeded max iterations`"
+      let info =
+            ExhaustionInfo
+              { partialOutput = lastAssistantText msgs,
+                iterationsUsed = iteration,
+                toolsCalled = countToolUses msgs,
+                messages = msgs
+              }
+      logError
+        cfg.logger
+        "Agent loop exceeded max iterations"
+        [ ("iterations", T.pack (show info.iterationsUsed)),
+          ("tools_called", T.pack (show info.toolsCalled)),
+          ("partial_output_length", T.pack (show (T.length info.partialOutput)))
+        ]
+      pure $ AgentExhausted info
   | otherwise = do
       -- Check cancellation before starting a new iteration
       cancelled <- cfg.isCancelled
@@ -336,6 +371,29 @@ extractToolUses = filter isToolUse
   where
     isToolUse (ToolUseBlock {}) = True
     isToolUse _ = False
+
+lastAssistantText :: [ClaudeMessage] -> Text
+lastAssistantText msgs =
+  case [extractTextContent c | ClaudeMessage Assistant c <- reverse msgs] of
+    (t : _) -> t
+    [] -> ""
+
+countToolUses :: [ClaudeMessage] -> Int
+countToolUses msgs =
+  sum [length (extractToolUses c) | ClaudeMessage _ c <- msgs]
+
+-- | JSON shape used as the delegate's tool_error body on exhaustion;
+-- documented in issue #49 so the orchestrator can branch on @status@.
+formatExhaustion :: ExhaustionInfo -> Text
+formatExhaustion info =
+  decodeUtf8 . LBS.toStrict $
+    encode $
+      object
+        [ "status" .= failureTag MaxIterations,
+          "iterations_used" .= info.iterationsUsed,
+          "tools_called" .= info.toolsCalled,
+          "partial_output" .= info.partialOutput
+        ]
 
 -- | Execute a single tool use with policy checking
 executeToolUse :: Logger -> ToolRegistry -> PermissionConfig -> ApprovalFunction -> ContentBlock -> IO ToolResult

--- a/src/Elwood/Event.hs
+++ b/src/Elwood/Event.hs
@@ -63,7 +63,7 @@ import Elwood.Event.Types
     MediaType (..),
     SessionConfig (..),
   )
-import Elwood.Logging (Logger, logError, logInfo)
+import Elwood.Logging (Logger, logError, logInfo, logWarn)
 import Elwood.Metrics (MetricsStore, metricsObserver, metricsSource)
 import Elwood.Notify (Severity (..), formatNotify, sanitizeBackticks, wrapInCode)
 import Elwood.Prompt (assemblePrompt)
@@ -338,6 +338,40 @@ handleEventCore env event callbacks = do
         ]
 
       pure (Right responseText)
+    Claude.AgentExhausted info -> do
+      -- Persist the partial turn and surface its text to the user rather
+      -- than discard work that hit the iteration cap.
+      case mConversationId of
+        Nothing -> pure ()
+        Just cid -> env.conversations.appendMessages cid info.messages prof.cache
+
+      let suffix =
+            "\n\n"
+              <> formatNotify
+                Error
+                ( "**Agent loop:** `exceeded max iterations ("
+                    <> T.pack (show info.iterationsUsed)
+                    <> ", "
+                    <> T.pack (show info.toolsCalled)
+                    <> " tool calls)`"
+                )
+          delivered =
+            if T.null info.partialOutput
+              then suffix
+              else info.partialOutput <> suffix
+
+      callbacks.onResponse delivered
+
+      logWarn
+        lgr
+        "Event handled with iteration exhaustion"
+        [ ("source", formatSource src),
+          ("iterations_used", T.pack (show info.iterationsUsed)),
+          ("tools_called", T.pack (show info.toolsCalled)),
+          ("partial_output_length", T.pack (show (T.length info.partialOutput)))
+        ]
+
+      pure (Right delivered)
     Claude.AgentCancelled -> do
       logInfo lgr "Event cancelled by user" [("source", formatSource src)]
       -- Turn discarded — don't save anything or deliver a response

--- a/src/Elwood/Tools/AsyncTask.hs
+++ b/src/Elwood/Tools/AsyncTask.hs
@@ -31,7 +31,7 @@ import Data.Ord (Down (..))
 import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Time (NominalDiffTime, UTCTime, diffUTCTime, getCurrentTime, nominalDiffTimeToSeconds)
-import Elwood.Claude.AgentLoop (AgentResult (..))
+import Elwood.Claude.AgentLoop (AgentResult (..), formatExhaustion)
 import Elwood.Claude.Types (ToolSchema (..))
 import Elwood.Tools.Types
 import GHC.Conc (STM, TVar, atomically, newTVarIO, readTVar, writeTVar)
@@ -338,6 +338,7 @@ listAllTasks store = do
       let status = case mResult of
             Nothing -> "running"
             Just (Right (AgentSuccess _ _)) -> "completed"
+            Just (Right (AgentExhausted _)) -> "exhausted"
             Just (Right AgentCancelled) -> "cancelled"
             Just (Right (AgentError _)) -> "failed"
             Just (Left _) -> "failed"
@@ -375,9 +376,10 @@ consumeAndFormat store tid r = do
 -- | Format a completed task result
 formatResult :: Either SomeException AgentResult -> IO ToolResult
 formatResult (Right (AgentSuccess text _)) = pure $ toolSuccess text
+formatResult (Right (AgentExhausted info)) = pure $ toolError (formatExhaustion info)
 formatResult (Right (AgentError err)) = pure $ toolError err
-formatResult (Right AgentCancelled) = pure $ toolError "Task was cancelled"
-formatResult (Left exc) = pure $ toolError $ "Task failed with exception: " <> T.pack (show exc)
+formatResult (Right AgentCancelled) = pure $ toolError $ taggedError Cancelled "Task was cancelled"
+formatResult (Left exc) = pure $ toolError $ taggedError Unexpected ("Task failed with exception: " <> T.pack (show exc))
 
 -- | Cancel all running async tasks. Returns the number of tasks cancelled.
 -- Uses 'Async.uninterruptibleCancel' so that an async exception arriving

--- a/src/Elwood/Tools/Delegate.hs
+++ b/src/Elwood/Tools/Delegate.hs
@@ -20,7 +20,7 @@ import Data.Time (NominalDiffTime)
 import Data.UUID qualified as UUID
 import Data.UUID.V4 qualified as UUID
 import Elwood.AgentSettings (AgentOverrides (..), AgentPreset (..), AgentProfile (..), CacheOverrides (..), ToolSearchConfig (..), resolveProfile, toOverrides)
-import Elwood.Claude.AgentLoop (AgentConfig (..), AgentResult (..), runAgentTurn)
+import Elwood.Claude.AgentLoop (AgentConfig (..), AgentResult (..), ExhaustionInfo (..), formatExhaustion, runAgentTurn)
 import Elwood.Claude.Client (ClaudeClient)
 import Elwood.Claude.Observer (ToolUseCallback)
 import Elwood.Claude.Types (ClaudeMessage (..), ContentBlock (..), Role (..), ToolName (..), ToolSchema (..), jsonSchemaFormat)
@@ -170,7 +170,7 @@ mkDelegateTaskTool logger client baseRegistry approve parentProfile pruning work
                   runAgentTurn subConfig [] userMsg
                     `catch` \(e :: SomeException) -> do
                       logError logger "Delegate sub-agent error" [("error", T.pack (show e))]
-                      pure $ AgentError $ "Sub-agent error: " <> T.pack (show e)
+                      pure $ AgentError $ taggedError Unexpected $ "Sub-agent error: " <> T.pack (show e)
 
             case (di.async, asyncStore) of
               (True, Just store) -> do
@@ -187,7 +187,7 @@ mkDelegateTaskTool logger client baseRegistry approve parentProfile pruning work
                 a <-
                   Async.async $ do
                     mResult <- timeout taskTimeout runWithCatch
-                    pure $ fromMaybe (AgentError "Async task timed out") mResult
+                    pure $ fromMaybe (AgentError (taggedError Timeout "Async task timed out")) mResult
                 insertTask store taskId taskLabel a
                 logInfo
                   logger
@@ -204,16 +204,25 @@ mkDelegateTaskTool logger client baseRegistry approve parentProfile pruning work
                 case mResult of
                   Nothing -> do
                     logInfo logger "Delegate task timed out" []
-                    pure $ toolError "Delegate task timed out."
+                    pure $ toolError $ taggedError Timeout "Delegate task timed out."
                   Just (AgentSuccess responseText _) -> do
                     logInfo
                       logger
                       "Delegate task completed"
                       [("response_length", T.pack (show (T.length responseText)))]
                     pure $ toolSuccess responseText
+                  Just (AgentExhausted info) -> do
+                    logInfo
+                      logger
+                      "Delegate task hit iteration cap"
+                      [ ("iterations_used", T.pack (show info.iterationsUsed)),
+                        ("tools_called", T.pack (show info.toolsCalled)),
+                        ("partial_output_length", T.pack (show (T.length info.partialOutput)))
+                      ]
+                    pure $ toolError (formatExhaustion info)
                   Just AgentCancelled -> do
                     logInfo logger "Delegate task cancelled" []
-                    pure $ toolError "Task was cancelled"
+                    pure $ toolError $ taggedError Cancelled "Task was cancelled"
                   Just (AgentError err) -> do
                     logError logger "Delegate task failed" [("error", err)]
                     pure $ toolError err

--- a/src/Elwood/Tools/Types.hs
+++ b/src/Elwood/Tools/Types.hs
@@ -15,6 +15,11 @@ module Elwood.Tools.Types
     -- * Result Helpers
     toolSuccess,
     toolError,
+    taggedError,
+
+    -- * Failure Modes
+    FailureMode (..),
+    failureTag,
   )
 where
 
@@ -84,3 +89,30 @@ toolSuccess = ToolSuccess
 -- | Create an error result
 toolError :: Text -> ToolResult
 toolError = ToolError
+
+-- | The way a tool-level operation can fail. Surfaced verbatim to the
+-- delegating agent so it can branch on the kind without parsing prose.
+data FailureMode
+  = -- | Sub-agent hit its @max_iterations@ cap before reaching end_turn.
+    MaxIterations
+  | -- | Wall-clock timeout (e.g. @timeout_seconds@ on a delegate task).
+    Timeout
+  | -- | User cancellation (e.g. @/stop@ or @cancel_task@).
+    Cancelled
+  | -- | Caught exception or other unclassified failure.
+    Unexpected
+  deriving stock (Show, Eq)
+
+-- | Wire-level tag for a failure mode. The 'MaxIterations' variant uses
+-- the longer form because it is also the JSON @status@ in delegate
+-- exhaustion bodies (see 'Elwood.Claude.AgentLoop.formatExhaustion').
+failureTag :: FailureMode -> Text
+failureTag MaxIterations = "max_iterations_exceeded"
+failureTag Timeout = "timeout"
+failureTag Cancelled = "cancelled"
+failureTag Unexpected = "error"
+
+-- | Prefix an error message with a parseable failure-mode tag so the
+-- orchestrator can branch on the kind without parsing prose.
+taggedError :: FailureMode -> Text -> Text
+taggedError mode msg = "[" <> failureTag mode <> "] " <> msg

--- a/test/Test/Elwood/Tools/AsyncTask.hs
+++ b/test/Test/Elwood/Tools/AsyncTask.hs
@@ -5,7 +5,7 @@ import Control.Concurrent.MVar (newEmptyMVar, takeMVar)
 import Data.Aeson (Value (..), object, (.=))
 import Data.Text (Text)
 import Data.Text qualified as T
-import Elwood.Claude.AgentLoop (AgentResult (..))
+import Elwood.Claude.AgentLoop (AgentResult (..), ExhaustionInfo (..))
 import Elwood.Tools.AsyncTask (TaskId (..), cancelAllTasks, insertTask, mkAwaitTaskTool, mkCancelTaskTool, mkCheckTaskTool, newAsyncTaskStore)
 import Elwood.Tools.Types
 import Test.Tasty
@@ -86,6 +86,46 @@ checkTaskRoundTripTests =
         let tool = mkCheckTaskTool store
         result <- tool.execute (object ["task_id" .= ("err-id" :: Text)])
         result @?= ToolError "something went wrong",
+      testCase "poll exhausted task returns JSON tool_error with partial output" $ do
+        store <- newAsyncTaskStore 3600
+        let info =
+              ExhaustionInfo
+                { partialOutput = "draft results so far",
+                  iterationsUsed = 10,
+                  toolsCalled = 8,
+                  messages = []
+                }
+        a <- Async.async $ pure $ AgentExhausted info
+        _ <- Async.wait a
+        insertTask store (TaskId "ex-id") "exhausted task" a
+        let tool = mkCheckTaskTool store
+        result <- tool.execute (object ["task_id" .= ("ex-id" :: Text)])
+        case result of
+          ToolError t -> do
+            assertBool "should contain status tag" (T.isInfixOf "max_iterations_exceeded" t)
+            assertBool "should contain iterations_used" (T.isInfixOf "\"iterations_used\":10" t)
+            assertBool "should contain tools_called" (T.isInfixOf "\"tools_called\":8" t)
+            assertBool "should contain partial_output" (T.isInfixOf "draft results so far" t)
+          _ -> assertFailure $ "expected ToolError, got: " <> show result,
+      testCase "exhausted task shows 'exhausted' status in list" $ do
+        store <- newAsyncTaskStore 3600
+        let info =
+              ExhaustionInfo
+                { partialOutput = "",
+                  iterationsUsed = 5,
+                  toolsCalled = 0,
+                  messages = []
+                }
+        a <- Async.async $ pure $ AgentExhausted info
+        _ <- Async.wait a
+        insertTask store (TaskId "list-ex-id") "listed exhausted" a
+        let tool = mkCheckTaskTool store
+        result <- tool.execute (object [])
+        case result of
+          ToolSuccess t -> do
+            assertBool "should contain list-ex-id" (T.isInfixOf "list-ex-id" t)
+            assertBool "should contain 'exhausted' status" (T.isInfixOf "exhausted" t)
+          _ -> assertFailure $ "expected ToolSuccess, got: " <> show result,
       testCase "finished task is consumed on first check" $ do
         store <- newAsyncTaskStore 3600
         a <- Async.async $ pure $ AgentSuccess "one-time result" []


### PR DESCRIPTION
Closes #49.

## Summary

- New `AgentExhausted ExhaustionInfo` variant on `AgentResult` so iteration-cap exits carry the last assistant text, the iteration / tool-call counts, and the turn's messages instead of being discarded as a bare error.
- `delegate_task` formats `AgentExhausted` as a JSON `tool_error` body — `{"status":"max_iterations_exceeded","iterations_used":N,"tools_called":K,"partial_output":"..."}` — so the orchestrator can salvage partial work or prompt a continuation rather than retrying from scratch.
- Other delegate-layer failures get parseable bracket-tagged error strings (`[timeout]`, `[cancelled]`, `[error]`) sourced from a single `FailureMode` ADT in `Elwood.Tools.Types`, so the kind of failure is recoverable by the orchestrator without parsing English.
- At the top level (Telegram), iteration exhaustion is now treated as a partial success: messages are persisted and the partial text is delivered to the user with a clear note appended, rather than the whole turn being lost.
- Async tasks surface the same JSON body when consumed via `check_task` / `await_task`; the listing shows an `exhausted` status alongside `completed`/`running`/`cancelled`/`failed`.

Out of scope for this PR: issue #49 part 3 (giving the sub-agent visibility into its remaining iteration budget so it can finalize early). Marked optional in the issue and a noticeably larger change; happy to follow up in a separate PR.

## Test plan

- [x] `nix develop -c cabal build` clean
- [x] `nix develop -c cabal test` — 374/374 pass (added 2 round-trip tests covering the exhausted async-task path: JSON body shape + `exhausted` status in the list view)
- [x] `nix fmt` clean (cabal-fmt, d2, hlint, nixfmt, ormolu)
- [x] `nix flake check` — all checks pass (build, weeder, pre-commit, NixOS module VM tests)
- [ ] Live smoke test: trigger an exhausted delegate end-to-end and confirm the JSON body lands as a tool_error in the orchestrator's history

🤖 Generated with [Claude Code](https://claude.com/claude-code)