### PR TITLE
Fix delegate timeout tag swallowed by sub-agent catch

### DIFF
--- a/elwood.cabal
+++ b/elwood.cabal
@@ -39,6 +39,7 @@ library
     Elwood.Config
     Elwood.Event
     Elwood.Event.Types
+    Elwood.Exception
     Elwood.Image
     Elwood.Logging
     Elwood.MCP

--- a/src/Elwood/Claude/AgentLoop.hs
+++ b/src/Elwood/Claude/AgentLoop.hs
@@ -8,7 +8,7 @@ module Elwood.Claude.AgentLoop
 where
 
 import Control.Concurrent.Async (mapConcurrently)
-import Control.Exception (SomeAsyncException, SomeException, fromException, throwIO, try)
+import Control.Exception (SomeException)
 import Data.Aeson (Value (..), encode, object, (.=))
 import Data.ByteString.Lazy qualified as LBS
 import Data.Set (Set)
@@ -35,6 +35,7 @@ import Elwood.Claude.Types
     stopReasonToText,
   )
 import Elwood.Config (PruningConfig (..))
+import Elwood.Exception (catchSync)
 import Elwood.Logging (Logger, logError, logInfo, logWarn)
 import Elwood.Notify (Severity (..), formatNotify, sanitizeBackticks)
 import Elwood.Permissions (PermissionConfig, ToolPolicy (..), getToolPolicy)
@@ -350,15 +351,10 @@ executeToolUses ::
   IO [ToolResult]
 executeToolUses lgr reg perms approve = mapConcurrently execSafe
   where
-    execSafe block = do
-      r <- try @SomeException (executeToolUse lgr reg perms approve block)
-      case r of
-        Right result -> pure result
-        Left e
-          | Just (_ :: SomeAsyncException) <- fromException e -> throwIO e
-          | otherwise -> do
-              logError lgr "Tool execution threw exception" [("error", T.pack (show e))]
-              pure $ ToolError $ "Tool execution failed: " <> T.take 500 (T.pack (show e))
+    execSafe block =
+      executeToolUse lgr reg perms approve block `catchSync` \(e :: SomeException) -> do
+        logError lgr "Tool execution threw exception" [("error", T.pack (show e))]
+        pure $ ToolError $ "Tool execution failed: " <> T.take 500 (T.pack (show e))
 
 -- | Extract text content from content blocks
 extractTextContent :: [ContentBlock] -> Text

--- a/src/Elwood/Exception.hs
+++ b/src/Elwood/Exception.hs
@@ -1,0 +1,16 @@
+module Elwood.Exception
+  ( catchSync,
+  )
+where
+
+import Control.Exception (SomeAsyncException, SomeException, catch, fromException, throwIO)
+
+-- | Like 'catch', but only catches synchronous exceptions. Async exceptions
+-- (e.g. 'System.Timeout.Timeout') are re-thrown so the surrounding
+-- machinery — timeouts, cancellation — still fires.
+catchSync :: IO a -> (SomeException -> IO a) -> IO a
+catchSync action handler =
+  action `catch` \e ->
+    case fromException e of
+      Just (_ :: SomeAsyncException) -> throwIO e
+      Nothing -> handler e

--- a/src/Elwood/Tools/Delegate.hs
+++ b/src/Elwood/Tools/Delegate.hs
@@ -5,7 +5,7 @@ module Elwood.Tools.Delegate
 where
 
 import Control.Concurrent.Async qualified as Async
-import Control.Exception (SomeException, catch)
+import Control.Exception (SomeAsyncException, SomeException, fromException, throwIO, try)
 import Data.Aeson (Value, object, (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KM
@@ -166,11 +166,19 @@ mkDelegateTaskTool logger client baseRegistry approve parentProfile pruning work
                     }
                 userMsg = ClaudeMessage User [TextBlock di.task]
 
-            let runWithCatch =
-                  runAgentTurn subConfig [] userMsg
-                    `catch` \(e :: SomeException) -> do
-                      logError logger "Delegate sub-agent error" [("error", T.pack (show e))]
-                      pure $ AgentError $ taggedError Unexpected $ "Sub-agent error: " <> T.pack (show e)
+            let runWithCatch = do
+                  -- Only catch synchronous exceptions. Async exceptions (e.g.
+                  -- 'System.Timeout.Timeout' from the outer 'timeout') must
+                  -- propagate so the caller's timeout machinery still fires;
+                  -- swallowing them would render the [timeout] tag unreachable.
+                  r <- try @SomeException (runAgentTurn subConfig [] userMsg)
+                  case r of
+                    Right res -> pure res
+                    Left e
+                      | Just (_ :: SomeAsyncException) <- fromException e -> throwIO e
+                      | otherwise -> do
+                          logError logger "Delegate sub-agent error" [("error", T.pack (show e))]
+                          pure $ AgentError $ taggedError Unexpected $ "Sub-agent error: " <> T.pack (show e)
 
             case (di.async, asyncStore) of
               (True, Just store) -> do

--- a/src/Elwood/Tools/Delegate.hs
+++ b/src/Elwood/Tools/Delegate.hs
@@ -5,7 +5,7 @@ module Elwood.Tools.Delegate
 where
 
 import Control.Concurrent.Async qualified as Async
-import Control.Exception (SomeAsyncException, SomeException, fromException, throwIO, try)
+import Control.Exception (SomeException)
 import Data.Aeson (Value, object, (.=))
 import Data.Aeson qualified as Aeson
 import Data.Aeson.KeyMap qualified as KM
@@ -25,6 +25,7 @@ import Elwood.Claude.Client (ClaudeClient)
 import Elwood.Claude.Observer (ToolUseCallback)
 import Elwood.Claude.Types (ClaudeMessage (..), ContentBlock (..), Role (..), ToolName (..), ToolSchema (..), jsonSchemaFormat)
 import Elwood.Config (PruningConfig)
+import Elwood.Exception (catchSync)
 import Elwood.Logging (Logger, logError, logInfo)
 import Elwood.Metrics (MetricsStore, metricsObserver)
 import Elwood.Notify (truncateText)
@@ -166,19 +167,10 @@ mkDelegateTaskTool logger client baseRegistry approve parentProfile pruning work
                     }
                 userMsg = ClaudeMessage User [TextBlock di.task]
 
-            let runWithCatch = do
-                  -- Only catch synchronous exceptions. Async exceptions (e.g.
-                  -- 'System.Timeout.Timeout' from the outer 'timeout') must
-                  -- propagate so the caller's timeout machinery still fires;
-                  -- swallowing them would render the [timeout] tag unreachable.
-                  r <- try @SomeException (runAgentTurn subConfig [] userMsg)
-                  case r of
-                    Right res -> pure res
-                    Left e
-                      | Just (_ :: SomeAsyncException) <- fromException e -> throwIO e
-                      | otherwise -> do
-                          logError logger "Delegate sub-agent error" [("error", T.pack (show e))]
-                          pure $ AgentError $ taggedError Unexpected $ "Sub-agent error: " <> T.pack (show e)
+            let runWithCatch =
+                  runAgentTurn subConfig [] userMsg `catchSync` \(e :: SomeException) -> do
+                    logError logger "Delegate sub-agent error" [("error", T.pack (show e))]
+                    pure $ AgentError $ taggedError Unexpected $ "Sub-agent error: " <> T.pack (show e)
 
             case (di.async, asyncStore) of
               (True, Just store) -> do


### PR DESCRIPTION
Follow-up to #53 (issue #49).

## Summary

A user reported that timed-out delegate tasks were surfacing as `[error] Sub-agent error: <<timeout>>` instead of the expected `[timeout] Delegate task timed out.` from the `FailureMode` ADT. Confirmed on two independent triggers (httpbin delay + literal `sleep 30`).

Root cause: in `Elwood.Tools.Delegate`, `runWithCatch` wrapped `runAgentTurn` in `catch @SomeException`, which catches *all* exceptions — including the `Timeout` async exception that `System.Timeout.timeout` uses to interrupt the inner action. `timeout` then saw `runWithCatch` return normally with an `AgentError`, returned `Just (...)`, and the `[timeout]` branch was never reached.

Fix: catch only synchronous exceptions; rethrow async ones (`SomeAsyncException`) so the outer `timeout` still fires. Same pattern already used by `executeToolUses` in `Elwood.Claude.AgentLoop`.

## Test plan

- [x] `nix develop -c cabal build` clean
- [x] `nix develop -c cabal test` — 374/374 pass (existing tests cover the sync timeout path's return-`Nothing` shape; the bug was that `timeout` never *returned* `Nothing`)
- [x] `nix fmt` clean
- [ ] Live re-run of the reporter's failing case (httpbin delay / `sleep 30`) — expect `[timeout] Delegate task timed out.` from the sync path or `[timeout] Async task timed out` from the async path

🤖 Generated with [Claude Code](https://claude.com/claude-code)