### PR TITLE
Add per-call timeout_seconds override for MCP tools

### DIFF
--- a/src/Elwood/MCP/Client.hs
+++ b/src/Elwood/MCP/Client.hs
@@ -7,6 +7,7 @@ module Elwood.MCP.Client
 
     -- * JSON-RPC Communication
     sendRequest,
+    defaultRequestTimeoutSeconds,
   )
 where
 
@@ -39,9 +40,9 @@ import System.Process
   )
 import System.Timeout (timeout)
 
--- | Response timeout in microseconds (30 seconds)
-responseTimeoutMicros :: Int
-responseTimeoutMicros = 30 * 1000000
+-- | Default response timeout in seconds when a caller doesn't specify one.
+defaultRequestTimeoutSeconds :: Int
+defaultRequestTimeoutSeconds = 30
 
 -- | Spawn and initialize an MCP server
 spawnServer :: Logger -> MCPServerConfig -> IO (Either MCPError MCPServer)
@@ -151,7 +152,7 @@ initializeMCPServer logger server = do
                 ]
           ]
 
-  initResult <- sendRequest server "initialize" (Just initParams)
+  initResult <- sendRequest server defaultRequestTimeoutSeconds "initialize" (Just initParams)
   case initResult of
     Left err -> pure $ Left err
     Right _ -> do
@@ -172,9 +173,10 @@ sendNotification logger server method_ params_ = do
   BS.hPut server.stdin jsonLine
   hFlush server.stdin
 
--- | Send a JSON-RPC request and wait for response (with timeout)
-sendRequest :: MCPServer -> Text -> Maybe Value -> IO (Either MCPError Value)
-sendRequest server method_ params_ = do
+-- | Send a JSON-RPC request and wait for response, timing out after the
+-- given number of seconds.
+sendRequest :: MCPServer -> Int -> Text -> Maybe Value -> IO (Either MCPError Value)
+sendRequest server timeoutSecs method_ params_ = do
   reqId <- atomicModifyIORef' server.requestId (\n -> (n + 1, n + 1))
 
   let request =
@@ -200,11 +202,11 @@ sendRequest server method_ params_ = do
       pure $ Left $ MCPRequestError $ "Failed to send request: " <> T.pack (show e)
     Right () -> do
       -- Wait for the reader thread to dispatch our response
-      result <- timeout responseTimeoutMicros (takeMVar mvar)
+      result <- timeout (timeoutSecs * 1_000_000) (takeMVar mvar)
       case result of
         Nothing -> do
           atomicModifyIORef' server.pendingRequests (\m -> (Map.delete reqId m, ()))
-          pure $ Left $ MCPRequestError "Response timeout (30s)"
+          pure $ Left $ MCPRequestError $ "Response timeout (" <> T.pack (show timeoutSecs) <> "s)"
         Just r -> pure r
 
 -- | Background thread that reads JSON-RPC responses from stdout and dispatches

--- a/src/Elwood/MCP/Registry.hs
+++ b/src/Elwood/MCP/Registry.hs
@@ -7,11 +7,19 @@ module Elwood.MCP.Registry
 
     -- * Server Management
     startMCPServers,
+
+    -- * Schema augmentation
+    extractTimeout,
+    injectTimeoutProperty,
+    schemaDeclaresTimeout,
+    maxRequestTimeoutSeconds,
   )
 where
 
 import Control.Exception (SomeException, catch)
 import Data.Aeson (FromJSON (..), Result (..), Value (..), fromJSON, object, withObject, (.:), (.=))
+import Data.Aeson.Key (Key)
+import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KM
 import Data.Maybe (fromMaybe)
 import Data.Text (Text)
@@ -20,10 +28,20 @@ import Data.Vector qualified as V
 import Elwood.Claude.Types (ToolName (..), ToolSchema (..))
 import Elwood.Config (MCPServerConfig (..))
 import Elwood.Logging (Logger, logInfo, logWarn)
-import Elwood.MCP.Client (sendRequest, spawnServer, stopServer)
+import Elwood.MCP.Client (defaultRequestTimeoutSeconds, sendRequest, spawnServer, stopServer)
 import Elwood.MCP.Types
 import Elwood.Tools.Registry (ToolRegistry, registerTool)
 import Elwood.Tools.Types (Tool (..), ToolResult (..))
+
+-- | Maximum seconds the agent may request via the injected @timeout_seconds@
+-- argument on an MCP tool call. Caps any single MCP request so a slow or hung
+-- server can't block a turn indefinitely.
+maxRequestTimeoutSeconds :: Int
+maxRequestTimeoutSeconds = 300
+
+-- | Argument key the agent uses to override the per-call MCP request timeout.
+timeoutArgKey :: Key
+timeoutArgKey = "timeout_seconds"
 
 -- | Response from tools/list
 newtype ToolsListResponse = ToolsListResponse
@@ -37,7 +55,7 @@ instance FromJSON ToolsListResponse where
 -- | Query available tools from an MCP server
 discoverTools :: MCPServer -> IO (Either MCPError [MCPTool])
 discoverTools server = do
-  result <- sendRequest server "tools/list" Nothing
+  result <- sendRequest server defaultRequestTimeoutSeconds "tools/list" Nothing
   case result of
     Left err -> pure $ Left err
     Right value -> do
@@ -51,18 +69,26 @@ fromJSONValue v = case fromJSON v of
   Error _ -> Nothing
   Success a -> Just a
 
--- | Convert an MCP tool to an Elwood Tool
+-- | Convert an MCP tool to an Elwood Tool. If the upstream schema already
+-- owns a @timeout_seconds@ property, we leave it (and its value) alone;
+-- otherwise we inject one and intercept it as a per-request timeout override.
 toTool :: Text -> MCPServer -> MCPTool -> Tool
 toTool serverName server mcpTool =
-  Tool
-    { schema =
-        ToolSchema
-          { name = ToolName ("mcp_" <> serverName <> "_" <> mcpTool.name),
-            description = fromMaybe "(MCP tool)" mcpTool.description,
-            inputSchema = ensureTypeObject mcpTool.inputSchema
-          },
-      execute = executeMCPTool server mcpTool
-    }
+  let baseSchema = ensureTypeObject mcpTool.inputSchema
+      (schemaWithTimeout, extract)
+        | schemaDeclaresTimeout mcpTool.inputSchema =
+            (baseSchema, \v -> Right (defaultRequestTimeoutSeconds, v))
+        | otherwise =
+            (injectTimeoutProperty baseSchema, extractTimeout)
+   in Tool
+        { schema =
+            ToolSchema
+              { name = ToolName ("mcp_" <> serverName <> "_" <> mcpTool.name),
+                description = fromMaybe "(MCP tool)" mcpTool.description,
+                inputSchema = schemaWithTimeout
+              },
+          execute = executeMCPTool server mcpTool extract
+        }
 
 -- | Ensure the input schema has type: "object" at the top level
 ensureTypeObject :: Value -> Value
@@ -70,24 +96,79 @@ ensureTypeObject (Object obj) =
   Object $ KM.insert "type" (String "object") obj
 ensureTypeObject v = v
 
--- | Execute an MCP tool
-executeMCPTool :: MCPServer -> MCPTool -> Value -> IO ToolResult
-executeMCPTool server mcpTool input = do
-  let params_ =
-        object
-          [ "name" .= mcpTool.name,
-            "arguments" .= input
-          ]
+-- | True if the upstream tool's input schema already declares a property
+-- named @timeout_seconds@ — in which case we defer to the server's semantics
+-- instead of intercepting the value.
+schemaDeclaresTimeout :: Value -> Bool
+schemaDeclaresTimeout (Object obj) = case KM.lookup "properties" obj of
+  Just (Object props) -> KM.member timeoutArgKey props
+  _ -> False
+schemaDeclaresTimeout _ = False
 
-  result <-
-    sendRequest server "tools/call" (Just params_)
-      `catch` \(e :: SomeException) ->
-        pure $ Left $ MCPRequestError $ T.pack $ show e
+-- | Add a @timeout_seconds@ property to the tool's input schema so the agent
+-- can override the per-request MCP timeout.
+injectTimeoutProperty :: Value -> Value
+injectTimeoutProperty (Object obj) =
+  let props = case KM.lookup "properties" obj of
+        Just (Object p) -> p
+        _ -> KM.empty
+      props' = KM.insert timeoutArgKey timeoutSchema props
+   in Object $ KM.insert "properties" (Object props') obj
+injectTimeoutProperty v = v
 
-  case result of
-    Left (MCPToolError _code msg) -> pure $ ToolError msg
-    Left err -> pure $ ToolError $ T.pack $ show err
-    Right value -> pure $ ToolSuccess $ formatToolResult value
+-- | JSON Schema fragment describing the injected @timeout_seconds@ argument.
+timeoutSchema :: Value
+timeoutSchema =
+  object
+    [ "type" .= ("integer" :: Text),
+      "minimum" .= (1 :: Int),
+      "maximum" .= maxRequestTimeoutSeconds,
+      "description"
+        .= ( "Maximum seconds to wait for this MCP request before failing. \
+             \Defaults to "
+               <> T.pack (show defaultRequestTimeoutSeconds)
+               <> "s. Use a larger value for slow upstreams."
+           )
+    ]
+
+executeMCPTool ::
+  MCPServer ->
+  MCPTool ->
+  (Value -> Either Text (Int, Value)) ->
+  Value ->
+  IO ToolResult
+executeMCPTool server mcpTool extract input =
+  case extract input of
+    Left err -> pure $ ToolError err
+    Right (timeoutSecs, args) -> do
+      let params_ =
+            object
+              [ "name" .= mcpTool.name,
+                "arguments" .= args
+              ]
+
+      result <-
+        sendRequest server timeoutSecs "tools/call" (Just params_)
+          `catch` \(e :: SomeException) ->
+            pure $ Left $ MCPRequestError $ T.pack $ show e
+
+      case result of
+        Left (MCPToolError _code msg) -> pure $ ToolError msg
+        Left err -> pure $ ToolError $ T.pack $ show err
+        Right value -> pure $ ToolSuccess $ formatToolResult value
+
+-- | Pull the optional @timeout_seconds@ argument out of a tool input object,
+-- clamping it into [1, maxRequestTimeoutSeconds]. Returns the chosen timeout
+-- and the remaining arguments to forward to the MCP server.
+extractTimeout :: Value -> Either Text (Int, Value)
+extractTimeout (Object obj) =
+  case KM.lookup timeoutArgKey obj of
+    Nothing -> Right (defaultRequestTimeoutSeconds, Object obj)
+    Just (Number n) ->
+      let clamped = max 1 (min maxRequestTimeoutSeconds (round n))
+       in Right (clamped, Object (KM.delete timeoutArgKey obj))
+    Just _ -> Left $ "Invalid '" <> Key.toText timeoutArgKey <> "' parameter (must be an integer)"
+extractTimeout v = Right (defaultRequestTimeoutSeconds, v)
 
 -- | Format tool result for display
 formatToolResult :: Value -> Text

--- a/test/Test/Elwood/MCP.hs
+++ b/test/Test/Elwood/MCP.hs
@@ -9,7 +9,13 @@ import Data.Text qualified as T
 import Elwood.Config (MCPServerConfig (..))
 import Elwood.Logging (newLogger)
 import Elwood.Logging qualified as Log
-import Elwood.MCP.Client (sendRequest, spawnServer, stopServer)
+import Elwood.MCP.Client (defaultRequestTimeoutSeconds, sendRequest, spawnServer, stopServer)
+import Elwood.MCP.Registry
+  ( extractTimeout,
+    injectTimeoutProperty,
+    maxRequestTimeoutSeconds,
+    schemaDeclaresTimeout,
+  )
 import Elwood.MCP.Types
 import System.IO (hClose, hPutStr)
 import System.IO.Temp (withSystemTempFile)
@@ -24,7 +30,8 @@ tests =
       mcpToolTests,
       mcpErrorTests,
       mcpServerConfigTests,
-      concurrentRequestTests
+      concurrentRequestTests,
+      timeoutArgTests
     ]
 
 jsonRpcTests :: TestTree
@@ -223,7 +230,7 @@ concurrentRequestTests =
                   ( \i -> do
                       mv <- newEmptyMVar
                       _ <- forkIO $ do
-                        r <- sendRequest server "echo" (Just (object ["n" .= i]))
+                        r <- sendRequest server defaultRequestTimeoutSeconds "echo" (Just (object ["n" .= i]))
                         putMVar mv r
                       pure mv
                   )
@@ -236,4 +243,55 @@ concurrentRequestTests =
                     Right _ -> pure ()
                 )
                 (zip [(1 :: Int) ..] results)
+    ]
+
+-- | Tests for the per-call @timeout_seconds@ argument injected into every
+-- MCP-bridged tool (issue #50).
+timeoutArgTests :: TestTree
+timeoutArgTests =
+  testGroup
+    "timeout_seconds argument"
+    [ testCase "default timeout when arg missing" $
+        extractTimeout (object ["url" .= ("https://example.com" :: T.Text)])
+          @?= Right (defaultRequestTimeoutSeconds, object ["url" .= ("https://example.com" :: T.Text)]),
+      testCase "explicit timeout extracted and stripped from args" $
+        extractTimeout (object ["url" .= ("u" :: T.Text), "timeout_seconds" .= (90 :: Int)])
+          @?= Right (90, object ["url" .= ("u" :: T.Text)]),
+      testCase "timeout above max is clamped" $
+        extractTimeout (object ["timeout_seconds" .= (10000 :: Int)])
+          @?= Right (maxRequestTimeoutSeconds, object []),
+      testCase "timeout below 1 is clamped to 1" $
+        extractTimeout (object ["timeout_seconds" .= (0 :: Int)])
+          @?= Right (1, object []),
+      testCase "non-integer timeout returns error" $
+        extractTimeout (object ["timeout_seconds" .= ("ten" :: T.Text)])
+          @?= Left "Invalid 'timeout_seconds' parameter (must be an integer)",
+      testCase "schema injection adds property to empty schema" $ do
+        let augmented = injectTimeoutProperty (object ["type" .= ("object" :: T.Text)])
+        case augmented of
+          Object obj -> case KM.lookup "properties" obj of
+            Just (Object props) ->
+              KM.member "timeout_seconds" props @?= True
+            _ -> assertFailure "expected properties object"
+          _ -> assertFailure "expected augmented object",
+      testCase "schema injection preserves existing properties" $ do
+        let original =
+              object
+                [ "type" .= ("object" :: T.Text),
+                  "properties" .= object ["url" .= object ["type" .= ("string" :: T.Text)]]
+                ]
+        case injectTimeoutProperty original of
+          Object obj -> case KM.lookup "properties" obj of
+            Just (Object props) -> do
+              KM.member "url" props @?= True
+              KM.member "timeout_seconds" props @?= True
+            _ -> assertFailure "expected properties object"
+          _ -> assertFailure "expected augmented object",
+      testCase "schemaDeclaresTimeout detects upstream property" $ do
+        schemaDeclaresTimeout (object ["properties" .= object ["timeout_seconds" .= object []]])
+          @?= True
+        schemaDeclaresTimeout (object ["properties" .= object ["url" .= object []]])
+          @?= False
+        schemaDeclaresTimeout (object ["type" .= ("object" :: T.Text)])
+          @?= False
     ]


### PR DESCRIPTION
Closes #50.

## Summary
- Every MCP-bridged tool (e.g. `mcp_fetch_fetch`) now accepts an optional `timeout_seconds` argument (`1..300`, default `30`) that overrides the JSON-RPC response timeout for that single call. Slow upstreams that previously failed at the hardcoded 30s ceiling can now be reached without dropping back to `curl` via `run_command`.
- `MCP.Client.sendRequest` takes the timeout as an explicit parameter; the timeout error message reports the actual value used (e.g. `Response timeout (90s)`), addressing the bonus ask in the issue about distinguishing "site is slow" from "URL is wrong" — the agent at least knows what budget it actually had.
- If an upstream MCP tool already declares its own `timeout_seconds` property, we leave both the schema and the value untouched, so we never shadow legitimate server semantics.

## Test plan
- [x] `nix develop -c cabal build` clean
- [x] `nix develop -c cabal test` — 382 pass, including 8 new tests under `MCP > timeout_seconds argument` (default fallback, explicit override + stripping, max/min clamping, type-validation error, schema injection on empty + populated schemas, `schemaDeclaresTimeout` upstream-collision detection)
- [x] `nix fmt` clean (cabal-fmt, hlint, nixfmt, ormolu, d2)
- [x] `nix flake check` green (build, weeder, NixOS module tests)
- [ ] Manual smoke: invoke `mcp_fetch_fetch` against a slow URL with `timeout_seconds: 90` once the branch is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)